### PR TITLE
Set up GitHub to run tests

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -1,0 +1,13 @@
+name: Run tests
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Run tests
+        run: python src/validate_bts.py


### PR DESCRIPTION
See here for the successful test run that was triggered by this pull request: https://github.com/blkerby/Mosaic/actions/runs/6203506316

Once this is merged, going forward the test results will show up on commits and pull requests in an easier-to-see place (i.e. in the main repo instead of in my fork).

I also played around with this first in a different branch, where I checked that it looks as it should when the tests fail: https://github.com/blkerby/Mosaic/tree/github-actions-testing