### PR TITLE
Update 'Matrix' -> 'Outline'

### DIFF
--- a/Projects/Base/ASM/Area Palettes.asm
+++ b/Projects/Base/ASM/Area Palettes.asm
@@ -923,5 +923,5 @@ AreaPalettes_X:
 %PaletteFile(18, SHR, Base)
 %PaletteFile(19, SHR, Base)
 ; Exotic
-%PaletteFile(20, X, Matrix)
+%PaletteFile(20, X, Outline)
 warnpc $C1FFFF


### PR DESCRIPTION
I got this error when trying to assemble "Area Palettes.asm":
```
Area Palettes.asm:832 (called from Area Palettes.asm:926): error: (Efile_not_found): File '..\..\Matrix\Export\Tileset\SCE\20\palette.snes' wasn't found. [incbin ..\..\Matrix\Export\Tileset\SCE\20\palette.snes]`
```
It looks like the Matrix project got renamed to Outline but the reference here wasn't updated? So this PR updates it to Outline.