### PR TITLE
Apply rain and fog removal to FX initialization, not only to FX tilemap

### DIFF
--- a/Projects/Base/ASM/Area FX.asm
+++ b/Projects/Base/ASM/Area FX.asm
@@ -27,6 +27,9 @@ org $89AC57
 org $89AC25
   JSR GetFxType
   ;LDA $0009,X
+org $89AC3A
+  JSR GetFxType
+  ;LDA $0009,X
 org $89ABF8
   JSR GetFxPaletteBlend
   ;LDA $000F,X


### PR DESCRIPTION
I noticed that in scrolling sky rooms (OuterCrateria theme), using Power Bombs causes some graphical artifacts because the post-HUD IRQ overruns hblank. I played around with optimizing the IRQ handler, to boil down the critical section to just 3 instructions "sta $2130 : stx $2109 : sty $212C" but it still did not completely solve the overrun. Finally I realized that it's happening because of the rain FX. When Power Bombs are collected, the rain FX tilemap was no longer getting applied, but the rain FX itself was still getting loaded, including the HDMA object(s) that it creates, which cause the overrun. It's easily solved by applying the same conditional logic to which FX type is initialized as is already applied to which FX tilemap gets loaded. I assume this may be why the vanilla game avoids using the rain FX once Power Bombs are collected.