### PR TITLE
Fix palette blend in Pit Room

### DIFF
--- a/Projects/WestMaridia/Export/Rooms/OLD TOURIAN BOSS ROOM.xml
+++ b/Projects/WestMaridia/Export/Rooms/OLD TOURIAN BOSS ROOM.xml
@@ -843,13 +843,13 @@
           <surfacenew>FFFF</surfacenew>
           <surfacespeed>0000</surfacespeed>
           <surfacedelay>00</surfacedelay>
-          <type>00</type>
+          <type>0C</type>
           <transparency1_A>02</transparency1_A>
           <transparency2_B>30</transparency2_B>
           <liquidflags_C>00</liquidflags_C>
           <paletteflags>00</paletteflags>
           <animationflags>00</animationflags>
-          <paletteblend>00</paletteblend>
+          <paletteblend>62</paletteblend>
         </FX1>
       </FX1s>
       <Enemies killcount="00">


### PR DESCRIPTION
The fog showed with a wrong palette blend in the "awake" state (when Morph + Missiles are collected, regardless of whether the planet is awake). This changes it to have disabled fog in this state, consistent with what vanilla and other themes do.