### PR TITLE
West Maridia theme: Add fog in Climb

### DIFF
--- a/Projects/WestMaridia/Export/Rooms/OLD TOURIAN SHAFT.xml
+++ b/Projects/WestMaridia/Export/Rooms/OLD TOURIAN SHAFT.xml
@@ -5053,9 +5053,9 @@
           <surfacenew>FFFF</surfacenew>
           <surfacespeed>0000</surfacespeed>
           <surfacedelay>00</surfacedelay>
-          <type>00</type>
+          <type>0C</type>
           <transparency1_A>02</transparency1_A>
-          <transparency2_B>14</transparency2_B>
+          <transparency2_B>30</transparency2_B>
           <liquidflags_C>00</liquidflags_C>
           <paletteflags>00</paletteflags>
           <animationflags>00</animationflags>


### PR DESCRIPTION
The palette blend used in Climb (Zebes asleep state) looked wrong without the fog. Fog seems to look good here, and the neighboring room Pit Room has it already.