### PR TITLE
Crateria bugfixes

### DIFF
--- a/Projects/InnerCrateria/Export/Rooms/ATTIC MISSILE ROOM.xml
+++ b/Projects/InnerCrateria/Export/Rooms/ATTIC MISSILE ROOM.xml
@@ -152,7 +152,7 @@
           <transparency2_B>02</transparency2_B>
           <liquidflags_C>00</liquidflags_C>
           <paletteflags>00</paletteflags>
-          <animationflags>80</animationflags>
+          <animationflags>82</animationflags>
           <paletteblend>00</paletteblend>
         </FX1>
       </FX1s>
@@ -498,7 +498,7 @@
           <transparency2_B>02</transparency2_B>
           <liquidflags_C>00</liquidflags_C>
           <paletteflags>00</paletteflags>
-          <animationflags>00</animationflags>
+          <animationflags>02</animationflags>
           <paletteblend>00</paletteblend>
         </FX1>
       </FX1s>

--- a/Projects/InnerCrateria/Export/Rooms/WRECKED SHIP ENERGY TANK ROOM.xml
+++ b/Projects/InnerCrateria/Export/Rooms/WRECKED SHIP ENERGY TANK ROOM.xml
@@ -803,7 +803,7 @@
           <transparency2_B>02</transparency2_B>
           <liquidflags_C>00</liquidflags_C>
           <paletteflags>00</paletteflags>
-          <animationflags>00</animationflags>
+          <animationflags>02</animationflags>
           <paletteblend>00</paletteblend>
         </FX1>
       </FX1s>

--- a/Projects/OuterCrateria/Export/Rooms/WASTELAND.xml
+++ b/Projects/OuterCrateria/Export/Rooms/WASTELAND.xml
@@ -1029,7 +1029,7 @@
           <liquidflags_C>02</liquidflags_C>
           <paletteflags>80</paletteflags>
           <animationflags>03</animationflags>
-          <paletteblend>00</paletteblend>
+          <paletteblend>08</paletteblend>
         </FX1>
       </FX1s>
       <Enemies killcount="04">


### PR DESCRIPTION
Outer: Wasteland acid was grey
Inner: WS E-tank and Attic missile room spikes were not animated though they still hurt samus with the power off (attic missiles wasnt animated in either state)