### PR TITLE
Fix mismatched animations (spikes, water)

### DIFF
--- a/Projects/GreenBrinstar/Export/Rooms/BELOW BOTWOON QUICKSAND ROOM.xml
+++ b/Projects/GreenBrinstar/Export/Rooms/BELOW BOTWOON QUICKSAND ROOM.xml
@@ -183,8 +183,8 @@
           <surfacespeed>0000</surfacespeed>
           <surfacedelay>00</surfacedelay>
           <type>06</type>
-          <transparency1_A>18</transparency1_A>
-          <transparency2_B>02</transparency2_B>
+          <transparency1_A>02</transparency1_A>
+          <transparency2_B>18</transparency2_B>
           <liquidflags_C>03</liquidflags_C>
           <paletteflags>20</paletteflags>
           <animationflags>0C</animationflags>

--- a/Projects/LowerNorfair/Export/Rooms/WRECKED SHIP ENERGY TANK ROOM.xml
+++ b/Projects/LowerNorfair/Export/Rooms/WRECKED SHIP ENERGY TANK ROOM.xml
@@ -803,7 +803,7 @@
           <transparency2_B>02</transparency2_B>
           <liquidflags_C>00</liquidflags_C>
           <paletteflags>00</paletteflags>
-          <animationflags>00</animationflags>
+          <animationflags>02</animationflags>
           <paletteblend>48</paletteblend>
         </FX1>
       </FX1s>

--- a/Projects/MechaTourian/Export/Rooms/WRECKED SHIP ENERGY TANK ROOM.xml
+++ b/Projects/MechaTourian/Export/Rooms/WRECKED SHIP ENERGY TANK ROOM.xml
@@ -803,7 +803,7 @@
           <transparency2_B>02</transparency2_B>
           <liquidflags_C>00</liquidflags_C>
           <paletteflags>00</paletteflags>
-          <animationflags>00</animationflags>
+          <animationflags>02</animationflags>
           <paletteblend>00</paletteblend>
         </FX1>
       </FX1s>

--- a/Projects/UpperNorfair/Export/Rooms/OLD TOURIAN SUPER MISSILE.xml
+++ b/Projects/UpperNorfair/Export/Rooms/OLD TOURIAN SUPER MISSILE.xml
@@ -1792,7 +1792,7 @@
           <transparency2_B>02</transparency2_B>
           <liquidflags_C>40</liquidflags_C>
           <paletteflags>00</paletteflags>
-          <animationflags>00</animationflags>
+          <animationflags>02</animationflags>
           <paletteblend>08</paletteblend>
         </FX1>
       </FX1s>

--- a/Projects/YellowMaridia/Export/Rooms/ATTIC MISSILE ROOM.xml
+++ b/Projects/YellowMaridia/Export/Rooms/ATTIC MISSILE ROOM.xml
@@ -539,7 +539,7 @@
           <transparency2_B>02</transparency2_B>
           <liquidflags_C>00</liquidflags_C>
           <paletteflags>00</paletteflags>
-          <animationflags>00</animationflags>
+          <animationflags>02</animationflags>
           <paletteblend>00</paletteblend>
         </FX1>
       </FX1s>

--- a/Projects/YellowMaridia/Export/Rooms/WRECKED SHIP ENERGY TANK ROOM.xml
+++ b/Projects/YellowMaridia/Export/Rooms/WRECKED SHIP ENERGY TANK ROOM.xml
@@ -803,7 +803,7 @@
           <transparency2_B>02</transparency2_B>
           <liquidflags_C>00</liquidflags_C>
           <paletteflags>00</paletteflags>
-          <animationflags>00</animationflags>
+          <animationflags>02</animationflags>
           <paletteblend>00</paletteblend>
         </FX1>
       </FX1s>


### PR DESCRIPTION
Spikes not animated in some WS rooms with Phantoon alive, even though the spikes hurt:
- WS E-Tank (Mecha Tourian, Yellow Maridia, Lower Norfair)
- Attic Missiles (Yellow Maridia)

Also
- Spikes not animated in Old Tourian Supers (Upper Norfair)
- Water was behind the enemies in Below Botwoon Quicksand (Green Brinstar)

Didn't do a thorough check or anything, these were just ones that Maddo noticed while watching streams over the year.